### PR TITLE
Use `bash` instead of `cloud-init` to prep Droplet for Tailscale

### DIFF
--- a/src/digitalocean/Program.cs
+++ b/src/digitalocean/Program.cs
@@ -14,17 +14,47 @@ return await Deployment.RunAsync(() =>
     // Retrieve the Tailscale auth key from Pulumi secrets
     var tailscaleAuthKey = config.RequireSecret("tailscaleAuthKey");
 
-    // Define cloud-init script to join Tailscale with the provided auth key
-    var cloudInitScript = $"""
-                             
-                             #cloud-config
-                             runcmd:
-                               - curl -fsSL https://tailscale.com/install.sh | sh
-                               - echo 'net.ipv4.ip_forward = 1' | tee -a /etc/sysctl.d/99-tailscale.conf
-                               - echo 'net.ipv6.conf.all.forwarding = 1' | tee -a /etc/sysctl.d/99-tailscale.conf
-                               - sysctl -p /etc/sysctl.d/99-tailscale.conf
-                               - tailscale up --authkey {tailscaleAuthKey.Apply(key => key)} --accept-routes --ssh --advertise-exit-node
-                           """;
+    // Define a script to be run when the VM starts up
+    var initScript = tailscaleAuthKey.Apply(authKey => $$"""
+                                                         #!/bin/bash
+                                                                 set -eux  # Exit on error and print commands as they are executed
+                                                         
+                                                                 # Log the start of Tailscale installation
+                                                                 echo 'Starting Tailscale installation...' > /tmp/tailscale-setup.log
+                                                         
+                                                                 # Wait for apt-get to release the lock
+                                                                 while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
+                                                                     echo 'Waiting for apt lock...' >> /tmp/tailscale-setup.log
+                                                                     sleep 5
+                                                                 done
+                                                         
+                                                                 # Retry mechanism for downloading and installing Tailscale
+                                                                 for i in {1..5}; do
+                                                                     curl -fsSL https://tailscale.com/install.sh | sh && break || {
+                                                                         echo 'Tailscale installation failed, retrying in 5 seconds...' >> /tmp/tailscale-setup.log
+                                                                         sleep 5
+                                                                     }
+                                                                 done
+                                                         
+                                                                 # Check if Tailscale was installed
+                                                                 if ! command -v tailscale > /dev/null; then
+                                                                     echo 'Tailscale installation failed after 5 attempts' >> /tmp/tailscale-setup.log
+                                                                     exit 1
+                                                                 fi
+                                                                 
+                                                                 # Enable IP forwarding
+                                                                 echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
+                                                                 echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
+                                                                 sudo sysctl -p /etc/sysctl.d/99-tailscale.conf
+                                                         
+                                                                 # Start Tailscale with the provided auth key and enable SSH
+                                                                 echo 'Starting Tailscale...' >> /tmp/tailscale-setup.log
+                                                                 sudo tailscale up --authkey="{{authKey}}" --ssh --advertise-exit-node --accept-routes >> /tmp/tailscale-setup.log 2>&1
+                                                         
+                                                                 # Verify Tailscale status
+                                                                 tailscale status >> /tmp/tailscale-setup.log 2>&1
+
+                                                         """);
     
     // Create a DigitalOcean VPC
     var vpc = new Vpc("my-vpc", new VpcArgs
@@ -41,7 +71,7 @@ return await Deployment.RunAsync(() =>
         Region = region,
         Image = image,
         VpcUuid = vpc.Id,
-        UserData = cloudInitScript // Add the cloud-init script here
+        UserData = initScript
     });
 
     // Export Droplet's IP


### PR DESCRIPTION
Wasn't getting a lot of visibility into whether `cloud-init` was setup correctly or not, so going with a bash script I've used successfully on our Azure VMs before